### PR TITLE
Externalize  __set_errno_internal to hook it

### DIFF
--- a/libc/Android.mk
+++ b/libc/Android.mk
@@ -1080,7 +1080,7 @@ LOCAL_STRIP_MODULE := keep_symbols
 # create a "cloaked" dependency on libgcc.a in libc though the libraries, which is not what
 # you wanted!
 
-LOCAL_SHARED_LIBRARIES := libdl
+LOCAL_SHARED_LIBRARIES := libdl libdsyscalls
 LOCAL_WHOLE_STATIC_LIBRARIES := libc_common
 LOCAL_SYSTEM_SHARED_LIBRARIES :=
 

--- a/libc/bionic/__set_errno.cpp
+++ b/libc/bionic/__set_errno.cpp
@@ -42,10 +42,15 @@
 // old NDK apps.
 
 // This one is for internal use only and used by both LP32 and LP64 assembler.
-extern "C" __LIBC_HIDDEN__ long __set_errno_internal(int n) {
+
+#ifdef LIBC_STATIC
+extern "C" long __set_errno_internal(int n) {
   errno = n;
   return -1;
 }
+#else
+extern "C" long __set_errno_internal(int n);
+#endif
 
 // This one exists for the LP32 NDK and is not present at all in LP64.
 #if !defined(__LP64__)

--- a/libc/hybris/libdsyscalls.c
+++ b/libc/hybris/libdsyscalls.c
@@ -16,14 +16,14 @@
 
 #include <errno.h>
 
-/* Define __set_errno here so it can be hijacked by libhybris
+/* Define __set_errno_internal here so it can be hijacked by libhybris
  * at runtime (called from __set_syscall_errno)
- 
-int __set_errno(int n)
-{
-    errno = n;
-    return -1;
+ */
+
+long __set_errno_internal(int n) {
+  errno = n;
+  return -1;
 }
-*/
+
 
 


### PR DESCRIPTION
This is necessary in order to catch the access to
errno from the internal syscalls.

Change-Id: I86a78150b85c94e5aa51ddeb58b591c8939153ad
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>